### PR TITLE
test: Intercept all movies and test for both search features

### DIFF
--- a/cypress/e2e/homepage.cy.js
+++ b/cypress/e2e/homepage.cy.js
@@ -2,14 +2,37 @@ describe('Landing page tests', () => {
   beforeEach(() => {
     cy.fixture('mockMovieData').then((json) => {
       cy.intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2/movies', json)
-
+      cy.intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2/movies/436270',{
+        statusCode: 200,
+        fixture: 'mockFirstSingleMovieDetails.json'
+      })
+      cy.intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2/movies/982620',{
+        statusCode: 200,
+        fixture: 'mockLastSinglemovieData.json'
+      })
+      cy.intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2/movies/724495',{
+        statusCode: 200,
+        fixture: 'theWomanKing.json'
+      })
+      cy.intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2/movies/1013860',{
+        statusCode: 200,
+        fixture: 'RIPD2.json'
+      })
+      cy.intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2/movies/505642',{
+        statusCode: 200,
+        fixture: 'wakandaForever.json'
+      })
+      cy.intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2/movies/934641',{
+        statusCode: 200,
+        fixture: 'wakeUpDead.json'
+      })
     })
     .viewport(1280,800)
     .visit('http://localhost:3000')
   })
   it('should display all movies on the loading page', () => {
     cy.get('.app-title').contains('Rancid Tomatillos')
-    .get('.movies-wrapper').get('.card').should('have.length', 10)
+    .get('.movies-wrapper').get('.card').should('have.length', 6)
     .get('.card').first().should('contain.text', "Black Adam")
     .get('.card').last().should('contain.text', "Maneater")
   })

--- a/cypress/e2e/searchPage.cy.js
+++ b/cypress/e2e/searchPage.cy.js
@@ -1,0 +1,58 @@
+describe('Single movie details tests', () => {
+    beforeEach(() => {
+        cy.fixture('mockMovieData').then((json) => {
+          cy.intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2/movies', json)
+          cy.intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2/movies/436270',{
+            statusCode: 200,
+            fixture: 'mockFirstSingleMovieDetails.json'
+          })
+          cy.intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2/movies/982620',{
+            statusCode: 200,
+            fixture: 'mockLastSinglemovieData.json'
+          })
+          cy.intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2/movies/724495',{
+            statusCode: 200,
+            fixture: 'theWomanKing.json'
+          })
+          cy.intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2/movies/1013860',{
+            statusCode: 200,
+            fixture: 'RIPD2.json'
+          })
+          cy.intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2/movies/505642',{
+            statusCode: 200,
+            fixture: 'wakandaForever.json'
+          })
+          cy.intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2/movies/934641',{
+            statusCode: 200,
+            fixture: 'wakeUpDead.json'
+          })
+        })
+        .viewport(1280,800)
+        .visit('http://localhost:3000')
+      })
+    it('should be able to search for movies by title and get a filtered result of movies', () => {
+        cy.get('.search').type('black')
+        .get('.movies-wrapper').get('.card').should('have.length', 2)
+        .get('.card').first().should('contain.text', "Black Adam")
+        .get('.card').last().should('contain.text', "Black Panther")
+      })
+      it('should be able to search for movies by another title and get a filtered result of movies', () => {
+        cy.get('.search').type('the ')
+        .get('.movies-wrapper').get('.card').should('have.length', 3)
+        .get('.card').first().should('contain.text', "The Woman")
+        .get('.card').last().should('contain.text', "The Minute")
+      })
+
+      it('should be able to search for movies by genre and get a filtered result of movies', () => {
+        cy.get('#genres').select("Horror")
+        .get('.movies-wrapper').get('.card').should('have.length', 1)
+        .get('.card').first().should('contain.text', "Maneater")
+      })
+      it('should be able to search for movies by a different genre and get a filtered result of movies', () => {
+        cy.get('#genres').select("Action")
+        .get('.movies-wrapper').get('.card').should('have.length', 4)
+        .get('.card').first().should('contain.text', "Black Adam")
+        .get('.card').last().should('contain.text', "Wakanda Forever")
+      })
+})
+

--- a/cypress/e2e/singleMovie.cy.js
+++ b/cypress/e2e/singleMovie.cy.js
@@ -2,17 +2,36 @@ describe('Single movie details tests', () => {
   beforeEach(() => {
     cy.fixture('mockMovieData').then((json) => {
       cy.intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2/movies', json)
-
+      cy.intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2/movies/436270',{
+        statusCode: 200,
+        fixture: 'mockFirstSingleMovieDetails.json'
+      })
+      cy.intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2/movies/982620',{
+        statusCode: 200,
+        fixture: 'mockLastSinglemovieData.json'
+      })
+      cy.intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2/movies/724495',{
+        statusCode: 200,
+        fixture: 'theWomanKing.json'
+      })
+      cy.intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2/movies/1013860',{
+        statusCode: 200,
+        fixture: 'RIPD2.json'
+      })
+      cy.intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2/movies/505642',{
+        statusCode: 200,
+        fixture: 'wakandaForever.json'
+      })
+      cy.intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2/movies/934641',{
+        statusCode: 200,
+        fixture: 'wakeUpDead.json'
+      })
     })
     .viewport(1280,800)
     .visit('http://localhost:3000')
   })
   it('should take the user to the first single movie details page and update the URL', () => {
-    cy.intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2/movies/436270',{
-      statusCode: 200,
-      fixture: 'mockFirstSingleMovieDetails.json'
-    })
-    .get('.card button').first().click()
+    cy.get('.card button').first().click()
 
     .get('h2').should('contain.text', 'Black Adam')
     .get('.genres').get('.genre').should('have.length', 3).should('contain.text', "Action").should('contain.text', "Fantasy").should('contain.text', "Science Fiction")
@@ -20,11 +39,7 @@ describe('Single movie details tests', () => {
     .url().should('include', '436270')
   })
   it('should take the user to the last single movie details page and update the URL', () => {
-    cy.intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2/movies/982620',{
-      statusCode: 200,
-      fixture: 'mockLastSinglemovieData.json'
-    })
-    .get('.card button').last().click()
+    cy.get('.card button').last().click()
     .get('h2').should('contain.text', 'Maneater')
     .get('.genres').get('.genre').should('have.length', 2).should('contain.text', "Thriller").should('contain.text', "Horror")
     .get('.overview').should('contain.text', 'A group of friends on vacation in a seeming island paradise are stalked by an unrelenting great white after an accident leaves them stranded and left for dead.')
@@ -38,16 +53,12 @@ describe('Single movie details tests', () => {
     .get('.card button').first().click()
     .get('.button-close').click()
     .get('.app-title').contains('Rancid Tomatillos')
-    .get('.movies-wrapper').get('.card').should('have.length', 10)
+    .get('.movies-wrapper').get('.card').should('have.length', 6)
   })
-  it.only('user should be able to use forward/back navigation', () => {
-    cy.intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2/movies/982620',{
-      statusCode: 200,
-      fixture: 'mockLastSinglemovieData.json'
-    })
-    .get('.card button').last().click()
+  it('should be able to use forward/back navigation', () => {
+    cy.get('.card button').last().click()
     .go("back")
-    .get('.movies-wrapper').get('.card').should('have.length', 10)
+    .get('.movies-wrapper').get('.card').should('have.length', 6)
     .go("forward")
     .get('h2').should('contain.text', 'Maneater')
     .get('.genres').get('.genre').should('have.length', 2).should('contain.text', "Thriller").should('contain.text', "Horror")

--- a/cypress/fixtures/RIPD2.json
+++ b/cypress/fixtures/RIPD2.json
@@ -1,0 +1,21 @@
+{
+    "movie": {
+        "id": 1013860,
+        "title": "R.I.P.D. 2: Rise of the Damned",
+        "poster_path": "https://image.tmdb.org/t/p/original//g4yJTzMtOBUTAR2Qnmj8TYIcFVq.jpg",
+        "backdrop_path": "https://image.tmdb.org/t/p/original//kmzppWh7ljL6K9fXW72bPN3gKwu.jpg",
+        "release_date": "2022-11-15",
+        "overview": "When Sheriff Roy Pulsipher finds himself in the afterlife, he joins a special police force and returns to Earth to save humanity from the undead.",
+        "genres": [
+            "Fantasy",
+            "Action",
+            "Comedy",
+            "Crime"
+        ],
+        "budget": 130,
+        "revenue": 78324220,
+        "runtime": 102,
+        "tagline": "Meet the new law of the Afterlife.",
+        "average_rating": 7
+    }
+}

--- a/cypress/fixtures/mockMovieData.json
+++ b/cypress/fixtures/mockMovieData.json
@@ -41,38 +41,6 @@
           "release_date": "2022-11-04"
       },
       {
-          "id": 829799,
-          "poster_path": "https://image.tmdb.org/t/p/original//xdmmd437QdjcCls8yCQxrH5YYM4.jpg",
-          "backdrop_path": "https://image.tmdb.org/t/p/original//au4HUSWDRadIcl9CqySlw1kJMfo.jpg",
-          "title": "Paradise City",
-          "average_rating": 1,
-          "release_date": "2022-11-11"
-      },
-      {
-          "id": 972313,
-          "poster_path": "https://image.tmdb.org/t/p/original//fHQHC32dhom8u0OxC2hs2gYQh0M.jpg",
-          "backdrop_path": "https://image.tmdb.org/t/p/original//s65RPy7DiBS4PXvUR3fiTw5f725.jpg",
-          "title": "Blowback",
-          "average_rating": 2,
-          "release_date": "2022-06-17"
-      },
-      {
-          "id": 882598,
-          "poster_path": "https://image.tmdb.org/t/p/original//aPqcQwu4VGEewPhagWNncDbJ9Xp.jpg",
-          "backdrop_path": "https://image.tmdb.org/t/p/original//olPXihyFeeNvnaD6IOBltgIV1FU.jpg",
-          "title": "Smile",
-          "average_rating": 8,
-          "release_date": "2022-09-23"
-      },
-      {
-          "id": 830784,
-          "poster_path": "https://image.tmdb.org/t/p/original//irIS5Tn3TXjNi1R9BpWvGAN4CZ1.jpg",
-          "backdrop_path": "https://image.tmdb.org/t/p/original//c1bz69r0v065TGFA5nqBiKzPDys.jpg",
-          "title": "Lyle, Lyle, Crocodile",
-          "average_rating": 8,
-          "release_date": "2022-10-07"
-      },
-      {
           "id": 982620,
           "poster_path": "https://image.tmdb.org/t/p/original//pwf3DGuWB1AptvIzHhlGxDUNnQX.jpg",
           "backdrop_path": "https://image.tmdb.org/t/p/original//jHKNqz0LjM2dOUv5XDPmcSoYPEW.jpg",

--- a/cypress/fixtures/theWomanKing.json
+++ b/cypress/fixtures/theWomanKing.json
@@ -1,0 +1,20 @@
+{
+    "movie": {
+        "id": 724495,
+        "title": "The Woman King",
+        "poster_path": "https://image.tmdb.org/t/p/original//438QXt1E3WJWb3PqNniK0tAE5c1.jpg",
+        "backdrop_path": "https://image.tmdb.org/t/p/original//7zQJYV02yehWrQN6NjKsBorqUUS.jpg",
+        "release_date": "2022-09-15",
+        "overview": "The story of the Agojie, the all-female unit of warriors who protected the African Kingdom of Dahomey in the 1800s with skills and a fierceness unlike anything the world has ever seen, and General Nanisca as she trains the next generation of recruits and readies them for battle against an enemy determined to destroy their way of life.",
+        "genres": [
+            "Action",
+            "Drama",
+            "History"
+        ],
+        "budget": 50000000,
+        "revenue": 91000000,
+        "runtime": 135,
+        "tagline": "Her reign begins.",
+        "average_rating": 7
+    }
+}

--- a/cypress/fixtures/wakandaForever.json
+++ b/cypress/fixtures/wakandaForever.json
@@ -1,0 +1,20 @@
+{
+    "movie": {
+        "id": 505642,
+        "title": "Black Panther: Wakanda Forever",
+        "poster_path": "https://image.tmdb.org/t/p/original//ps2oKfhY6DL3alynlSqY97gHSsg.jpg",
+        "backdrop_path": "https://image.tmdb.org/t/p/original//xDMIl84Qo5Tsu62c9DGWhmPI67A.jpg",
+        "release_date": "2022-11-09",
+        "overview": "Queen Ramonda, Shuri, M’Baku, Okoye and the Dora Milaje fight to protect their nation from intervening world powers in the wake of King T’Challa’s death. As the Wakandans strive to embrace their next chapter, the heroes must band together with the help of War Dog Nakia and Everett Ross and forge a new path for the kingdom of Wakanda.",
+        "genres": [
+            "Action",
+            "Adventure",
+            "Science Fiction"
+        ],
+        "budget": 250000000,
+        "revenue": 733000000,
+        "runtime": 162,
+        "tagline": "Forever.",
+        "average_rating": 6.5
+    }
+}

--- a/cypress/fixtures/wakeUpDead.json
+++ b/cypress/fixtures/wakeUpDead.json
@@ -1,0 +1,19 @@
+{
+    "movie": {
+        "id": 934641,
+        "title": "The Minute You Wake Up Dead",
+        "poster_path": "https://image.tmdb.org/t/p/original//pUPwTbnAqfm95BZjNBnMMf39ChT.jpg",
+        "backdrop_path": "https://image.tmdb.org/t/p/original//sP1ShE4BGLkHSRqG9ZeGHg6C76t.jpg",
+        "release_date": "2022-11-04",
+        "overview": "A stockbroker in a small southern town gets embroiled in an insurance scam with a next-door neighbor that leads to multiple murders when a host of other people want in on the plot. Sheriff Thurmond Fowler, the by-the-book town sheriff for over four decades, works earnestly to try and unravel the town’s mystery and winds up getting more than he bargained for.",
+        "genres": [
+            "Thriller",
+            "Crime"
+        ],
+        "budget": 0,
+        "revenue": 0,
+        "runtime": 90,
+        "tagline": "Don't trust a soul.",
+        "average_rating": 5
+    }
+}


### PR DESCRIPTION
# Pull Request
## Description
Because the genre dropdown button is created responsively toward API data, every movie has been given an intercept to simulate a request for genre data. Intercepts for all movies have been created across all testing. Search By Title and Search By Genre have been tested to ensure functionality.

## Related Issues
Currently need to test for responsive design to complete Cypress testing

## Changes Made
- homepage.cy.js
- searchPage.cy.js
- singleMovie.cy.js
- RIPD2.json
- theWomanKing.json
- wakandaForever.json
- wakeUpDead.json

## Testing
Because the dropdown bar for genres is created by mapping fetch request data of all movies, testing now includes intercepts for every single movie id on the page. The ability to search by title and genre have been tested to ensure functionality. 

## Checklist
- [x] The code follows the project's coding standards.
- [x] Unit tests have been added or updated to cover the changes.
- [x] Documentation has been updated to reflect the changes (if applicable).
- [x] The code compiles without errors.
- [x] The changes have been tested locally and pass all relevant tests.
- [x] All new and existing tests pass.
- [x] The pull request has been reviewed by at least one other contributor.

## Additional Information
-NA

## Contributor(s)
Peter Kim and Zach Wolek